### PR TITLE
Update command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Resolves https://github.com/tuist/tuist/issues/YYY
+Resolves https://github.com/AckeeCZ/tapestry/issues/YYY
 
 ### Short description 📝
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Next
 
+### Added
+
+- Update command to update developer dependencies https://github.com/AckeeCZ/tapestry/pull/9 by @fortmarek
+
 ## 0.0.3
 
 ## 0.0.2

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Let's you say what dependency managers you want to check compatibility for.
 
 ### Run developer dependencies
 
-If you want to use developer dependencies using [SPM][spm], but don't want the users to download them since they are not essential to the project, you can add them to `tapestries/Package.swift`.
+If you want to use developer dependencies using [SPM][spm], but don't want the users to download them since they are not essential to the project, you can add them to `Tapestries/Package.swift`.
 
 If you then want to run it, just type:
 ```bash
@@ -188,9 +188,9 @@ tapestry run name-of-tool its-arguments
 ```
 And it will run the tool you have previously defined - which means all the project's contributors can use the same version of your tooling!
 
-### Update developer dependencies
+### Update local tapestry developer dependencies
 
-To updat dependencies defined in `tapestries/Package.swift`, you can simply run `tapestry update`.
+To update local tapestry version and dependencies defined in `Tapestries/Package.swift`, you can simply run `tapestry update`.
 
 ### Inspiration and thanks
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ tapestry run name-of-tool its-arguments
 ```
 And it will run the tool you have previously defined - which means all the project's contributors can use the same version of your tooling!
 
+### Update developer dependencies
+
+To updat dependencies defined in `tapestries/Package.swift`, you can simply run `tapestry update`.
+
 ### Inspiration and thanks
 
 I'd like to thank [tuist][tuist] for inspiration and help in this project. This project was also inspired by [rocket](https://github.com/shibapm/Rocket)

--- a/Sources/TapestryCore/Constants.swift
+++ b/Sources/TapestryCore/Constants.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public class Constants {
     public static let gitRepositoryURL = "https://github.com/AckeeCZ/tapestry.git"
-    public static let version = "0.0.2"
+    public static let version = "0.0.3"
     public static let swiftVersion: String = "5.1"
+    /// Name of tapestries folder where local tapestry, config and developer dependencies reside
+    public static let tapestriesName = "Tapestries"
 }

--- a/Sources/TapestryCore/Utils/PackageController.swift
+++ b/Sources/TapestryCore/Utils/PackageController.swift
@@ -101,7 +101,7 @@ public final class PackageController: PackageControlling {
     }
     
     public func run(_ tool: String, arguments: [String], path: AbsolutePath) throws {
-        let tapestriesPath = path.appending(component: "Tapestries")
+        let tapestriesPath = path.appending(component: Constants.tapestriesName)
         
         try FileHandler.shared.inDirectory(tapestriesPath) {
             do {

--- a/Sources/TapestryCore/Utils/PackageController.swift
+++ b/Sources/TapestryCore/Utils/PackageController.swift
@@ -63,6 +63,10 @@ public protocol PackageControlling {
     /// - Parameters:
     ///     - path: Name is derived from this path (last component)
     func name(from path: AbsolutePath) throws -> String
+    /// Updates packages
+    /// - Parameters:
+    ///     - path: Name is derived from this path (last component)
+    func update(path: AbsolutePath) throws
 }
 
 extension PackageControlling {
@@ -75,6 +79,10 @@ extension PackageControlling {
 public final class PackageController: PackageControlling {
     /// Shared instance
     public static var shared: PackageControlling = PackageController()
+    
+    public func update(path: AbsolutePath) throws {
+        try System.shared.runAndPrint(["swift", "package", "--package-path", path.pathString, "update"])
+    }
     
     public func initPackage(path: AbsolutePath, name: String) throws -> PackageType {
         let supportedPackageType: PackageType = try InputReader.shared.readEnumInput(question: "Choose package type:")

--- a/Sources/TapestryCoreTesting/Mocks/MockPackageController.swift
+++ b/Sources/TapestryCoreTesting/Mocks/MockPackageController.swift
@@ -6,6 +6,7 @@ public final class MockPackageController: PackageControlling {
     public var generateXcodeprojStub: ((AbsolutePath, AbsolutePath?) throws -> ())?
     public var runStub: ((String, [String], AbsolutePath) throws -> ())?
     public var nameStub: ((AbsolutePath) throws -> String)?
+    public var updateStub: ((AbsolutePath) throws -> ())?
     
     public func initPackage(path: AbsolutePath, name: String) throws -> PackageType {
         try initPackageStub?(path, name) ?? .library
@@ -21,5 +22,9 @@ public final class MockPackageController: PackageControlling {
     
     public func name(from path: AbsolutePath) throws -> String {
         try nameStub?(path) ?? ""
+    }
+    
+    public func update(path: AbsolutePath) throws {
+        try updateStub?(path)
     }
 }

--- a/Sources/TapestryGen/TapestriesGenerator.swift
+++ b/Sources/TapestryGen/TapestriesGenerator.swift
@@ -29,7 +29,7 @@ public final class TapestriesGenerator: TapestriesGenerating {
     
     public func generateTapestries(at path: AbsolutePath) throws {
         let name = try PackageController.shared.name(from: path)
-        let tapestriesPath = path.appending(component: "Tapestries")
+        let tapestriesPath = path.appending(component: Constants.tapestriesName)
         guard !FileHandler.shared.exists(tapestriesPath) else { throw TapestriesGeneratorError.tapestriesFolderExists(tapestriesPath) }
         let tapestryConfigPath = tapestriesPath.appending(RelativePath("Sources/TapestryConfig"))
         try FileHandler.shared.createFolder(tapestryConfigPath)
@@ -50,7 +50,7 @@ public final class TapestriesGenerator: TapestriesGenerating {
         import PackageDescription
 
         let package = Package(
-            name: "Tapestries",
+            name: Constants.tapestriesName,
             products: [
             .library(name: "TapestryConfig", targets: ["TapestryConfig"])
             ],

--- a/Sources/TapestryKit/Commands/CommandRegistry.swift
+++ b/Sources/TapestryKit/Commands/CommandRegistry.swift
@@ -43,6 +43,7 @@ public final class CommandRegistry {
         register(command: RunCommand.self)
         register(command: ActionCommand.self)
         register(command: ActionsCommand.self)
+        register(command: UpdateCommand.self)
     }
 
     init(errorHandler: ErrorHandling,

--- a/Sources/TapestryKit/Commands/CommandRegistry.swift
+++ b/Sources/TapestryKit/Commands/CommandRegistry.swift
@@ -85,7 +85,7 @@ public final class CommandRegistry {
     public func run() {
         do {
             // Run local version
-            let tapestriesPath = FileHandler.shared.currentPath.appending(component: "Tapestries")
+            let tapestriesPath = FileHandler.shared.currentPath.appending(component: Constants.tapestriesName)
             let processedArguments = processAllArguments()
             if !processArguments().contains(EditCommand.command),
                 !processArguments().contains(UpCommand.command),

--- a/Sources/TapestryKit/Commands/EditCommand.swift
+++ b/Sources/TapestryKit/Commands/EditCommand.swift
@@ -29,7 +29,7 @@ final class EditCommand: NSObject, Command {
             
         To edit `TapestryConfig` navigate to `TapestryConfig.swift`
         """)
-        try XcodeController.shared.open(at: path.appending(component: "Tapestries"))
+        try XcodeController.shared.open(at: path.appending(component: Constants.tapestriesName))
     }
     
     /// Obtain package path

--- a/Sources/TapestryKit/Commands/UpdateCommand.swift
+++ b/Sources/TapestryKit/Commands/UpdateCommand.swift
@@ -27,7 +27,7 @@ enum UpdateError: FatalError, Equatable {
     }
 }
 
-/// This command initializes Swift package with example in current empty directory
+/// This command updates local tapestry and develoepr dependencies
 final class UpdateCommand: NSObject, Command {
     static var command: String = "update"
     static var overview: String = "Updates local tapestry and dependencies in \"Tapestries/Package.swift\""

--- a/Sources/TapestryKit/Commands/UpdateCommand.swift
+++ b/Sources/TapestryKit/Commands/UpdateCommand.swift
@@ -27,7 +27,7 @@ enum UpdateError: FatalError, Equatable {
     }
 }
 
-/// This command updates local tapestry and develoepr dependencies
+/// This command updates local tapestry and developer dependencies
 final class UpdateCommand: NSObject, Command {
     static var command: String = "update"
     static var overview: String = "Updates local tapestry and dependencies in \"Tapestries/Package.swift\""

--- a/Sources/TapestryKit/Commands/UpdateCommand.swift
+++ b/Sources/TapestryKit/Commands/UpdateCommand.swift
@@ -1,0 +1,39 @@
+import Basic
+import protocol TuistCore.Command
+import Foundation
+import TapestryGen
+import SPMUtility
+import TapestryCore
+
+/// This command initializes Swift package with example in current empty directory
+final class UpdateCommand: NSObject, Command {
+    static var command: String = "update"
+    static var overview: String = "Updates local tapestry and dependencies in \"Tapestries/Package.swift\""
+
+    let pathArgument: OptionArgument<String>
+    
+    required init(parser: ArgumentParser) {
+        let subParser = parser.add(subparser: UpdateCommand.command, overview: UpdateCommand.overview)
+        
+        pathArgument = subParser.add(option: "--path",
+                                     shortName: "-p",
+                                     kind: String.self,
+                                     usage: "The path to your Swift framework",
+                                     completion: .filename)
+    }
+    
+    func run(with arguments: ArgumentParser.Result) throws {
+        let path = try self.path(arguments: arguments)
+        
+        try PackageController.shared.update(path: path)
+    }
+    
+    /// Obtain package path
+    private func path(arguments: ArgumentParser.Result) throws -> AbsolutePath {
+        if let path = arguments.get(pathArgument) {
+            return AbsolutePath(path, relativeTo: FileHandler.shared.currentPath)
+        } else {
+            return FileHandler.shared.currentPath
+        }
+    }
+}

--- a/Sources/TapestryKit/Generator/ResourceLocator.swift
+++ b/Sources/TapestryKit/Generator/ResourceLocator.swift
@@ -51,7 +51,7 @@ final class ResourceLocator: ResourceLocating {
     private func frameworkPath(_ name: String, path: AbsolutePath) throws -> AbsolutePath {
         let pathComponents = path.pathString.components(separatedBy: "/")
         guard
-            let tapestriesIndex = path.pathString.components(separatedBy: "/").firstIndex(where: { $0 == "Tapestries" })
+            let tapestriesIndex = path.pathString.components(separatedBy: "/").firstIndex(where: { $0 == Constants.tapestriesName })
         else {
             throw ResourceLocatingError.notFound(name)
         }

--- a/Tests/TapestryCoreTests/PackageControllerTests.swift
+++ b/Tests/TapestryCoreTests/PackageControllerTests.swift
@@ -64,4 +64,22 @@ final class PackageControllerTests: TapestryUnitTestCase {
         // Then
         XCTAssertEqual(try subject.name(from: fileHandler.currentPath.appending(component: name)), name)
     }
+    
+    func test_update_succeeds() throws {
+        // Given
+        let path = AbsolutePath("/test")
+        system.succeedCommand("swift", "package", "--package-path", path.pathString, "update")
+        
+        // Then
+        XCTAssertNoThrow(try subject.update(path: path))
+    }
+    
+    func test_update_fails() throws {
+        // Given
+        let path = AbsolutePath("/test")
+        system.errorCommand("swift", "package", "--package-path", path.pathString, "update")
+        
+        // Then
+        XCTAssertThrowsError(try subject.update(path: path))
+    }
 }

--- a/Tests/TapestryGenTests/TapestriesGeneratorTests.swift
+++ b/Tests/TapestryGenTests/TapestriesGeneratorTests.swift
@@ -14,7 +14,7 @@ final class TapestriesGeneratorTests: TapestryUnitTestCase {
     
     func test_generate_fails_when_directory_not_empty() throws {
         // Given
-        let tapestriesPath = fileHandler.currentPath.appending(component: "Tapestries")
+        let tapestriesPath = fileHandler.currentPath.appending(component: Constants.tapestriesName)
         try fileHandler.createFolder(tapestriesPath)
         
         // Then
@@ -26,7 +26,7 @@ final class TapestriesGeneratorTests: TapestryUnitTestCase {
         try subject.generateTapestries(at: fileHandler.currentPath)
         
         // Then
-        XCTAssertTrue(fileHandler.isFolder(fileHandler.currentPath.appending(component: "Tapestries")))
+        XCTAssertTrue(fileHandler.isFolder(fileHandler.currentPath.appending(component: Constants.tapestriesName)))
     }
     
     func test_generate_packageManifest() throws {
@@ -40,7 +40,7 @@ final class TapestriesGeneratorTests: TapestryUnitTestCase {
         import PackageDescription
 
         let package = Package(
-            name: "Tapestries",
+            name: Constants.tapestriesName,
             products: [
             .library(name: "TapestryConfig", targets: ["TapestryConfig"])
             ],

--- a/Tests/TapestryKitTests/EditCommandTests.swift
+++ b/Tests/TapestryKitTests/EditCommandTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Basic
 import SPMUtility
+import TapestryCore
 @testable import TapestryCoreTesting
 @testable import TapestryKit
 
@@ -27,6 +28,6 @@ final class EditCommandTests: TapestryUnitTestCase {
         try subject.run(with: result)
         
         // Then
-        XCTAssertEqual(fileHandler.currentPath.appending(component: "Tapestries"), openedPath)
+        XCTAssertEqual(fileHandler.currentPath.appending(component: Constants.tapestriesName), openedPath)
     }
 }

--- a/Tests/TapestryKitTests/UpdateCommandTests.swift
+++ b/Tests/TapestryKitTests/UpdateCommandTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Basic
 import SPMUtility
+import TapestryCore
 @testable import TapestryCoreTesting
 @testable import TapestryKit
 
@@ -16,11 +17,13 @@ final class UpdateCommandTests: TapestryUnitTestCase {
     
     func test_update_is_called_with_path() throws {
         // Given
-        let path = AbsolutePath("/test")
+        let path = fileHandler.currentPath.appending(component: "test")
         var updatePath: AbsolutePath?
         packageController.updateStub = {
             updatePath = $0
         }
+        let tapestriesPath = path.appending(component: Constants.tapestriesName)
+        try fileHandler.createFolder(tapestriesPath)
         
         let result = try parser.parse(["update", "--path", path.pathString])
         
@@ -28,6 +31,16 @@ final class UpdateCommandTests: TapestryUnitTestCase {
         try subject.run(with: result)
         
         // Then
-        XCTAssertEqual(updatePath, path)
+        XCTAssertEqual(updatePath, tapestriesPath)
+    }
+    
+    func test_update_fails_when_tapestries_not_found() throws {
+        // Given
+        let result = try parser.parse(["update"])
+        
+        // Then
+        XCTAssertThrowsSpecific(try subject.run(with: result),
+                                UpdateError.tapestriesFolderMissing(fileHandler.currentPath.appending(component: Constants.tapestriesName)))
+        
     }
 }

--- a/Tests/TapestryKitTests/UpdateCommandTests.swift
+++ b/Tests/TapestryKitTests/UpdateCommandTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import Basic
+import SPMUtility
+@testable import TapestryCoreTesting
+@testable import TapestryKit
+
+final class UpdateCommandTests: TapestryUnitTestCase {
+    private var subject: UpdateCommand!
+    private var parser: ArgumentParser!
+    
+    override func setUp() {
+        super.setUp()
+        parser = ArgumentParser.test()
+        subject = UpdateCommand(parser: parser)
+    }
+    
+    func test_update_is_called_with_path() throws {
+        // Given
+        let path = AbsolutePath("/test")
+        var updatePath: AbsolutePath?
+        packageController.updateStub = {
+            updatePath = $0
+        }
+        
+        let result = try parser.parse(["update", "--path", path.pathString])
+        
+        // When
+        try subject.run(with: result)
+        
+        // Then
+        XCTAssertEqual(updatePath, path)
+    }
+}


### PR DESCRIPTION
### Short description 📝

Updating developer dependencies and local tapestry version now requires to move to `tapestries` folder and run `swift package update` from there - this should be simpler.

### Solution 📦

To fix this we can introduce a new command `tapestry update` that will do the above commands by itself, making the job of the developers easier.

### Implementation 👩‍💻👨‍💻

Adding new `update` command to `PackageController` that runs `swift package update` in the path provided from `UpdateCommand` (that points to `Tapestries` folder)
